### PR TITLE
Include license file in sdists and wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.rst
 include *.txt
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,8 @@
 [bdist_wheel]
 universal=1
+
+[metadata]
+license_file = LICENSE
+
 [tool:pytest]
 pep8maxlinelength = 120


### PR DESCRIPTION
The terms of the MIT license require the license text be included with all copies of the software.